### PR TITLE
Changes necessary to build in F24 with GCC6 (std-c++14).

### DIFF
--- a/src/control/framework/nodebooter.cpp
+++ b/src/control/framework/nodebooter.cpp
@@ -141,7 +141,7 @@ void loadPRFExecParams (const std::string& prfFile, ExecParams& execParams)
         prf.load(prfStream);
     } catch (const ossie::parser_error& ex) {
         std::string parser_error_line = ossie::retrieveParserErrorLineNumber(ex.what());
-        LOG_ERROR(nodebooter, "Failed to parse PRF file " << prfStream<< ". " << parser_error_line << "The XML parser returned the following error: " << ex.what());
+        LOG_ERROR(nodebooter, "Failed to parse PRF file " << prfFile<< ". " << parser_error_line << "The XML parser returned the following error: " << ex.what());
         exit(EXIT_FAILURE);
     }
     prfStream.close();

--- a/src/control/sdr/dommgr/ApplicationFactory_impl.cpp
+++ b/src/control/sdr/dommgr/ApplicationFactory_impl.cpp
@@ -194,7 +194,7 @@ void ApplicationFactory_impl::ValidateSPD(CF::FileManager_ptr fileMgr,
                                           const bool require_prf, 
                                           const bool require_scd) {
   SoftPkg pkg;
-  ValidateSPD(fileMgr, pkg, false, false );
+  ValidateSPD(fileMgr, pkg, sfw_profile, require_prf, require_scd);
 }
 
 void ApplicationFactory_impl::ValidateSPD(CF::FileManager_ptr fileMgr, 

--- a/src/control/sdr/dommgr/applicationSupport.cpp
+++ b/src/control/sdr/dommgr/applicationSupport.cpp
@@ -853,7 +853,7 @@ const bool  ComponentInfo::isScaCompliant()
 
 bool ComponentInfo::isAssignedToDevice() const
 {
-    return assignedDevice;
+  return static_cast<bool>(assignedDevice);
 }
 
 bool ComponentInfo::checkStruct(CF::Properties &props)

--- a/src/testing/sdr/dev/devices/CppTestDevice/cpp/CppTestDevice.h
+++ b/src/testing/sdr/dev/devices/CppTestDevice/cpp/CppTestDevice.h
@@ -28,7 +28,7 @@ class CppTestDevice_i : public CppTestDevice_base
 {
     ENABLE_LOGGING
     public:
-		static const float MAX_LOAD = 4.0;
+		static constexpr float MAX_LOAD = 4.0;
 
 		CppTestDevice_i(char *devMgr_ior, char *id, char *lbl, char *sftwrPrfl);
         CppTestDevice_i(char *devMgr_ior, char *id, char *lbl, char *sftwrPrfl, char *compDev);


### PR DESCRIPTION
Changeset is originally referenced / described in [my StackOverflow question](http://stackoverflow.com/questions/38571741/building-redhawk-cf-from-source-on-fedora24/38579179#38579179).

Two of the changes appear to be GCC6 related, but the other two changes look like they would be necessary no matter the C++ standard in use. Since the relevant lines were last modified in February, it seems that if they were indeed bugs that they would have been fixed by now. Thus, I think these need careful review.

The `constexpr` keyword was added to C++ in c++11. I wasn't able to find docs that called out what versions of the standard RedhawkSDR needed to support - if something earlier is needed, this will probably need to be addressed by the preprocessor.

That said, with this changeset, I was able to build the CF in F24, as was @bagoulla. The changeset is also referenced in [this openembedded-hawk bug report](https://github.com/Axios-Engineering/openembedded-hawk/issues/4#issuecomment-235581101).
